### PR TITLE
BugFix for GOLANG/get rid of windows backslashes

### DIFF
--- a/src/services/languages/go/methodExtractor.ts
+++ b/src/services/languages/go/methodExtractor.ts
@@ -37,8 +37,11 @@ export class GoMethodExtractor implements IMethodExtractor{
             }
             packageName = match[1] 
             
-            if(modFolder !== docFolder)
-                packageName += '/' + path.relative(modFolder, docFolder);
+            if (modFolder !== docFolder) {
+                const relative = path.relative(modFolder, docFolder)
+                    .replace('\\', '/'); // get rid of windows backslashes
+                packageName += '/' + relative;
+            }
         }
 
         const methods: SymbolInfo[] = methodSymbols.map(s => {

--- a/src/services/languages/go/methodExtractor.ts
+++ b/src/services/languages/go/methodExtractor.ts
@@ -39,7 +39,7 @@ export class GoMethodExtractor implements IMethodExtractor{
             
             if (modFolder !== docFolder) {
                 const relative = path.relative(modFolder, docFolder)
-                    .replace('\\', '/'); // get rid of windows backslashes
+                    .replaceAll('\\', '/'); // get rid of windows backslashes
                 packageName += '/' + relative;
             }
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
 	"compilerOptions": {
 		"module": "commonjs",
-		"target": "ES2020",
+		"target": "ES2021",
 		"outDir": "out",
 		"lib": [
-			"ES2020",
+			"ES2021",
 			"dom"
 		],
 		"sourceMap": true,


### PR DESCRIPTION
the bug happens when go files resides in inner folders(2 and more) then the method extractor displays `\` (backslash) as file delimiter instead of standard `/` (slash).

Extra in this PR: Upgrade TS to **ES2021** in order to have support for method `replaceAll`