### PR TITLE
BugFix/overcome the problem with URI in windows

### DIFF
--- a/src/services/languages/go/methodExtractor.ts
+++ b/src/services/languages/go/methodExtractor.ts
@@ -4,41 +4,41 @@ import { DocumentSymbol, SymbolKind } from "vscode-languageclient";
 import { IMethodExtractor, SymbolInfo } from "../extractors";
 import { Logger } from '../../logger';
 
-export class GoMethodExtractor implements IMethodExtractor{
+export class GoMethodExtractor implements IMethodExtractor {
     public async extractMethods(document: vscode.TextDocument, docSymbols: DocumentSymbol[]): Promise<SymbolInfo[]> {
-        const methodSymbols = docSymbols.filter(s => s.kind+1 === SymbolKind.Method || s.kind+1 === SymbolKind.Function); 
-        if(!methodSymbols.length) {
+        const methodSymbols = docSymbols.filter(s => s.kind + 1 === SymbolKind.Method || s.kind + 1 === SymbolKind.Function);
+        if (!methodSymbols.length) {
             return [];
         }
 
-        const modFiles = await (await vscode.workspace.findFiles('**/go.mod')).map( x => x.fsPath);
+        const modFiles = await (await vscode.workspace.findFiles('**/go.mod')).map(x => x.fsPath);
         const normDocPath = document.uri.fsPath;
         const modFile = modFiles.find(f => normDocPath.startsWith(path.dirname(f)));
-        if(!modFile){
-            Logger.warn(`Could not resolve mod file for '${document.uri.path}'`)
+        if (!modFile) {
+            Logger.warn(`Could not resolve mod file for '${document.uri.path}'`);
             return [];
         }
 
         const modFolder = path.dirname(modFile);
         const docFolder = path.dirname(normDocPath);
         let packageName = '';
-        if(modFolder === docFolder){
+        if (modFolder === docFolder) {
             const match = document.getText().match(/^package (.+)$/m);
-            if(!match){
-                Logger.warn(`Could not found packakge name in '${document.uri.path}'`)
+            if (!match) {
+                Logger.warn(`Could not found packakge name in '${document.uri.path}'`);
                 return [];
             }
-            packageName = match[1]; 
+            packageName = match[1];
         }
-        if(!packageName || packageName !== 'main'){
+        if (!packageName || packageName !== 'main') {
             const modDocument = await vscode.workspace.openTextDocument(modFile);
             const match = modDocument.getText().match(/^module (.+)$/m);
-            if(!match){
-                Logger.warn(`Could not found module name in '${modFile}'`)
+            if (!match) {
+                Logger.warn(`Could not found module name in '${modFile}'`);
                 return [];
             }
-            packageName = match[1] 
-            
+            packageName = match[1];
+
             if (modFolder !== docFolder) {
                 const relative = path.relative(modFolder, docFolder)
                     .replace('\\', '/'); // get rid of windows backslashes
@@ -57,10 +57,10 @@ export class GoMethodExtractor implements IMethodExtractor{
                     new vscode.Position(s.range.start.line, s.range.start.character),
                     new vscode.Position(s.range.end.line, s.range.end.character)
                 )
-            }
+            };
         });
 
         return methods;
     }
-    
+
 }

--- a/src/services/languages/go/methodExtractor.ts
+++ b/src/services/languages/go/methodExtractor.ts
@@ -7,18 +7,20 @@ import { Logger } from '../../logger';
 export class GoMethodExtractor implements IMethodExtractor{
     public async extractMethods(document: vscode.TextDocument, docSymbols: DocumentSymbol[]): Promise<SymbolInfo[]> {
         const methodSymbols = docSymbols.filter(s => s.kind+1 === SymbolKind.Method || s.kind+1 === SymbolKind.Function); 
-        if(!methodSymbols.length)
+        if(!methodSymbols.length) {
             return [];
+        }
 
-        const modFiles = await vscode.workspace.findFiles('**/go.mod');
-        const modFile = modFiles.find(f => document.uri.path.startsWith(path.dirname(f.path)))
+        const modFiles = await (await vscode.workspace.findFiles('**/go.mod')).map( x => x.fsPath);
+        const normDocPath = document.uri.fsPath;
+        const modFile = modFiles.find(f => normDocPath.startsWith(path.dirname(f)));
         if(!modFile){
             Logger.warn(`Could not resolve mod file for '${document.uri.path}'`)
             return [];
         }
 
-        const modFolder = path.dirname(modFile.path);
-        const docFolder = path.dirname(document.uri.path);
+        const modFolder = path.dirname(modFile);
+        const docFolder = path.dirname(normDocPath);
         let packageName = '';
         if(modFolder === docFolder){
             const match = document.getText().match(/^package (.+)$/m);
@@ -32,13 +34,16 @@ export class GoMethodExtractor implements IMethodExtractor{
             const modDocument = await vscode.workspace.openTextDocument(modFile);
             const match = modDocument.getText().match(/^module (.+)$/m);
             if(!match){
-                Logger.warn(`Could not found module name in '${modFile.path}'`)
+                Logger.warn(`Could not found module name in '${modFile}'`)
                 return [];
             }
             packageName = match[1] 
             
-            if(modFolder !== docFolder)
-                packageName += '/' + path.relative(modFolder, docFolder);
+            if (modFolder !== docFolder) {
+                const relative = path.relative(modFolder, docFolder)
+                    .replace('\\', '/'); // get rid of windows backslashes
+                packageName += '/' + relative;
+            }
         }
 
         const methods: SymbolInfo[] = methodSymbols.map(s => {


### PR DESCRIPTION
### what problem does it solve?

sometimes in windows the `document.file.path` in file `methodExtractor.ts` returns `/C:/...` (the C in upper case),
while the `vscode.workspace.findFiles` returns URI's with `/c:/...` ( the C in lower case) - and it caused problems when comparing those.

### How was it solved?

using method `fsPath` instead of `path`, which states that it will fix the case of C drive letter.