### PR TITLE
Bug Fix/Python - FAST API, fix missing insights regarding endpoint

### DIFF
--- a/src/services/languages/python/fastapiEndpointExtractor.ts
+++ b/src/services/languages/python/fastapiEndpointExtractor.ts
@@ -3,6 +3,7 @@ import { DocumentInfoProvider } from './../../documentInfoProvider';
 import { SymbolTree } from './../symbolProvider';
 import { Token, TokenType } from '../tokens';
 import { EndpointInfo, IEndpointExtractor, SymbolInfo } from '../extractors';
+import { EndpointSchema } from '../../analyticsProvider';
 
 export class FastapiEndpointExtractor implements IEndpointExtractor
 {
@@ -91,7 +92,7 @@ export class FastapiEndpointExtractor implements IEndpointExtractor
             for (let j=0;j<pathParts.length-1;j++){
                 let possibleRoot = pathParts[j];
                 results.push(new EndpointInfo(
-                    possibleRoot + '$_$' + method + ' ' + prefix + path,
+                    possibleRoot + '$_$' + EndpointSchema.HTTP + method.toUpperCase() + ' ' + prefix + path,
                     method, 
                     path,
                     relevantFunc.range,


### PR DESCRIPTION
### How was it fixed?
add prefix of `epHTTP:` to the CodeObjectId of endpoint type

### Why this issue happened all of a sudden
Part of adding EndpointSchema as prefix to the endpoint name/route, this code section was not fixed accordingly.

TODO: add ref to issue num